### PR TITLE
fix(vertical tabs): text-decoration off

### DIFF
--- a/packages/module/patternfly-docs/content/examples/verticalTab.css
+++ b/packages/module/patternfly-docs/content/examples/verticalTab.css
@@ -18,6 +18,7 @@
 }
 .ws-react-e-vertical-tabs .vertical-tabs-pf-tab > a {
   color: var(--pf-t--global--text--color--regular);
+  text-decoration: none;
   display: inline-block;
   font-size: var(--pf-t--global--font--size--body--default);
   padding-block: var(--pf-t--global--spacer--xs);
@@ -30,7 +31,6 @@
   margin-inline-start: var(--pf-t--global--spacer--md);
 }
 .ws-react-e-vertical-tabs .vertical-tabs-pf-tab > a:hover, .ws-react-e-vertical-tabs .vertical-tabs-pf-tab > a:focus {
-  color: var(--pf-t--global--text--color--regular);
   background-color: var(--pf-t--global--background--color--action--plain--hover);
   text-decoration: none;
 }

--- a/packages/module/sass/react-catalog-view-extension/_vertical-tabs.scss
+++ b/packages/module/sass/react-catalog-view-extension/_vertical-tabs.scss
@@ -14,6 +14,7 @@
 
   > a {
     color: var( --pf-t--global--text--color--regular);
+    text-decoration: none;
     display: inline-block;
     font-size: 13px;
     padding: 3px 6px 3px 15px;

--- a/packages/module/sass/react-catalog-view-extension/_vertical-tabs.scss
+++ b/packages/module/sass/react-catalog-view-extension/_vertical-tabs.scss
@@ -24,7 +24,7 @@
 
     &:hover,
     &:focus {
-      color: var(--pf-t--global--text--color--brand--hover);
+      background-color: var(--pf-t--global--background--color--action--plain--hover);
       text-decoration: none;
     }
 


### PR DESCRIPTION
Closes https://github.com/patternfly/react-catalog-view/issues/74
Their shouldn't be an underline on the vertical tabs