### PR TITLE
fix(catalog-tile): titles over-run boundary for long names w/o breaks

### DIFF
--- a/packages/module/sass/react-catalog-view-extension/_catalog-tile.scss
+++ b/packages/module/sass/react-catalog-view-extension/_catalog-tile.scss
@@ -24,6 +24,7 @@
   font-size: 16px;
   font-weight: 400;
   padding-bottom: 16px;
+  overflow-wrap: break-word;
 
   .catalog-tile-pf-title {
     font-size: 15px;


### PR DESCRIPTION
fixes https://github.com/patternfly/react-catalog-view/issues/82

before:
![image](https://github.com/user-attachments/assets/1668ae1d-c957-4c3c-b3e2-01efb47c664e)


after:
![image](https://github.com/user-attachments/assets/bc9d6ed3-4a3a-48f3-8c9c-de94d325e1bb)
